### PR TITLE
Split the roadmap into template and UI tracks

### DIFF
--- a/docs/enhancement-roadmap.md
+++ b/docs/enhancement-roadmap.md
@@ -6,9 +6,13 @@ This document is the shared implementation plan for evolving the
 sankara:interactive Next.js + Storyblok template. It is intended for humans and
 coding agents. Keep statuses and architectural decisions current as work lands.
 
-The sequencing principle is:
+After the shared foundation, work splits into two tracks that run in parallel:
 
-> Quality gates -> UI architecture -> primitives -> Storyblok adapters -> page sections.
+> **Track A** (this repo): Storyblok plumbing — routing, caching, adapters, sections.
+> **Track B** (`@sankara/ui` repo): the reusable UI system, built without Storyblok.
+
+They join at Phase A3, where adapters translate CMS data into UI props. Until
+then neither track blocks the other.
 
 Storyblok types must not leak into the reusable UI package. Storyblok components
 adapt CMS data into stable UI component props.
@@ -20,18 +24,21 @@ adapt CMS data into stable UI component props.
 - `[x]` Complete
 - `[!]` Blocked or awaiting a decision
 
+## Decisions
+
+Record architectural decisions here as they are made, newest last.
+
+- **`@sankara/ui` lives in its own repository**, not as `packages/ui/` in this
+  template. This template consumes it as a published dependency. Rationale: a
+  template is cloned per project, and shipping the design-system source into
+  every clone is backwards; the "a consuming project can override brand tokens
+  without forking component logic" criterion is only tested honestly when the
+  consumer is external; and a workspace conversion would restructure this repo's
+  root, colliding with every open branch. Confirm the npm scope before publishing.
+
 ## Phase 0: Land the Baseline PR Stack
 
-Status: `[~]` PR #11 verification and merge remaining
-
-Land the existing work in dependency order:
-
-```text
-main
-└── #9 hardening
-    └── #10 Storyblok v7
-        └── #11 core patterns
-```
+Status: `[~]` All PRs merged; manual smoke-testing remains
 
 Tasks:
 
@@ -40,33 +47,32 @@ Tasks:
   merged baseline and merge it.
 - [x] Rebase PR #11, `feat/template-core-patterns`, onto PR #10.
 - [x] Resolve the rich-text implementation against the Storyblok v7 API.
-- [~] Run tests, typecheck, lint, and a production build. Tests, typecheck, and
-  lint pass locally; the production build remains outstanding.
-- [ ] Merge PR #11.
+- [x] Run tests, typecheck, lint, and a production build. The production build is
+  covered by the CI job added in Phase 1.
+- [x] Merge PR #11.
+- [ ] Smoke-test rich text, embedded bloks, preview editing, internal links, and
+  email links against a real space.
 
 Exit criteria:
 
-- All three PRs are represented in `main` in the order above.
-- Rich text, embedded bloks, preview editing, internal links, and email links
-  have been smoke-tested.
-- The working baseline passes all available quality checks.
+- All three PRs are represented in `main`.
+- The manual smoke test above has actually been run — everything below assumes
+  this baseline works.
 
 ## Phase 1: Baseline Reliability
 
-Status: `[ ]`
-
-Deliver as an independent PR before expanding the component catalogue.
+Status: `[~]` Implemented in PR #13, `feat/template-ci-foundation`; awaiting review
 
 Tasks:
 
-- [ ] Add GitHub Actions for immutable install, typecheck, lint, tests, and build.
-- [ ] Add `typecheck`, `format:check`, and combined `check` package scripts.
-- [ ] Add server/client environment validation with production-safe failures.
-- [ ] Return `null` only for real Storyblok 404 responses; surface unexpected
+- [x] Add GitHub Actions for immutable install, typecheck, lint, tests, and build.
+- [x] Add `typecheck`, `format:check`, and combined `check` package scripts.
+- [x] Add server/client environment validation with production-safe failures.
+- [x] Return `null` only for real Storyblok 404 responses; surface unexpected
   authentication, network, rate-limit, and server failures.
-- [ ] Make the production build reproducible in CI.
-- [ ] Add generated Storyblok schema/type drift detection.
-- [ ] Configure grouped dependency updates.
+- [x] Make the production build reproducible in CI.
+- [x] Add generated Storyblok schema/type drift detection.
+- [x] Configure grouped dependency updates.
 
 Exit criteria:
 
@@ -74,133 +80,80 @@ Exit criteria:
 - Invalid production configuration fails early with a useful error.
 - CMS outages do not silently appear as content 404s.
 
-## Phase 2: UI Foundation Decision
+---
 
-Status: `[ ]`
+# Track A — Template
 
-Run a focused Base UI versus Radix spike. Base UI is the current preference, but
-default styling is not a deciding factor.
+## Phase A1: Cleanup and Backports
 
-Implement the same small sample with both foundations:
+Status: `[ ]` Blocked on PR #13 merging (overlapping files)
 
-- Tabs
-- Dialog
-- Select or combobox
-- Animated popover
-- A server-rendered page containing client-side interaction
-
-Evaluate:
-
-- Accessibility and keyboard behavior
-- API consistency and composability
-- React Server Component boundaries
-- Styling and animation ergonomics
-- Bundle output
-- Test ergonomics
-- Form integration
-- Portals and Content Security Policy compatibility
-- Upgrade and maintenance model
+Findings from the numbers.ch backport audit and the repo over-engineering audit.
+One PR; all mechanical.
 
 Tasks:
 
-- [ ] Build and measure the Base UI sample.
-- [ ] Build and measure the Radix sample.
-- [ ] Record the decision in `docs/architecture/001-ui-foundation.md`.
-- [ ] Decide whether distribution uses a package, a private shadcn-compatible
-  registry, or both.
+- [ ] Fix per-page `openGraph` silently replacing the root layout's. Next does
+  not deep-merge that key, so `og:site_name`, `og:locale` and `og:type` are
+  missing on every content route. Export the defaults once from `lib/config.ts`
+  and spread into both; correct the now-false OG claim in `CLAUDE.md`.
+- [ ] Delete `lib/storyblok-image.ts` and its test — no callers outside the test.
+- [ ] Drop the unused `clsx` dependency.
+- [ ] Remove the four inert restated ignores in `eslint.config.mjs`
+  (`eslint-config-next` already applies them).
+- [ ] Replace `app/page.tsx` with an optional catch-all (`app/[[...slug]]`),
+  removing the duplicated `revalidate` export.
+- [ ] Shrink `sitemapPaths` to filter/map; collapse the identical `url`/`asset`
+  branches in `getHref`.
 
 Exit criteria:
 
-- The chosen foundation and rejected alternatives are documented with evidence.
-- The expected server/client boundary and dependency policy are explicit.
+- No dead exports, no unused dependencies, no inert configuration.
+- Open Graph defaults actually reach content routes.
 
-## Phase 3: Sankara UI Foundation
+## Phase A2: CMS-Editable Redirects
 
-Status: `[ ]`
+Status: `[!]` Awaiting a decision on the matching strategy
 
-Establish the reusable system before building a large component catalogue.
-The provisional package name is `@sankara/ui`; confirm availability before
-publishing.
+Client requirement: editors change redirects in Storyblok and cannot trigger a
+redeploy. Today `lib/redirects.mjs` feeds `next.config.mjs` at build time only.
 
-Suggested structure:
+Do **not** port the numbers.ch implementation as-is. Its matcher compares
+`source === pathname` (so `:slug*` patterns silently fail), skips any path
+containing a dot (so `/impressum.html` never redirects), drops the query string,
+and derives the redirect origin from the Host header.
 
-```text
-packages/ui/
-├── components/
-├── hooks/
-├── styles/
-├── test/
-├── tokens/
-└── utilities/
-```
+Two candidate designs — pick one before writing code:
+
+1. **Resolve at the 404 boundary.** `getStory` already returns `null` before
+   `notFound()` in the catch-all; look up the redirect list there and `redirect()`.
+   No per-request proxy, no self-fetch, reads go through `lib/storyblok-api.ts`
+   with existing cache tags. Costs nothing on hits. Does not fire for a source
+   path that still resolves to a live story, and covers only paths reaching the
+   catch-all.
+2. **Resolve in `proxy.ts`.** Catches every path including live ones, at the cost
+   of work on every request and a cache-read path that must work outside the
+   normal RSC context.
 
 Tasks:
 
-- [ ] Define semantic color, typography, spacing, radius, border, shadow,
-  motion, breakpoint, focus, and layering tokens.
-- [ ] Define theming and customer-brand override rules.
-- [ ] Document naming, composition, variants, refs, controlled state,
-  `className` escape hatches, and server/client boundaries.
-- [ ] Establish reduced-motion and accessibility acceptance policies.
-- [ ] Add Storybook or an equivalent isolated component workbench.
-- [ ] Add unit, accessibility, and visual-regression test infrastructure.
-- [ ] Establish package and registry release/versioning workflows.
+- [ ] Decide between (1) and (2) and record it under Decisions.
+- [ ] Define the `data/redirects` schema (source, destination, permanent).
+- [ ] Implement, preserving query strings and never trusting the Host header.
+- [ ] Keep developer-authored pattern redirects in `next.config.mjs`; the CMS
+  story is for exact-path retirement.
+- [ ] Test: exact match, no match, query preservation, permanent vs temporary.
 
 Exit criteria:
 
-- Components can be developed and tested independently of Storyblok.
-- A consuming project can override brand tokens without forking component logic.
-- Accessibility and API rules are enforceable, not only documented.
+- An editor can retire a URL and see the redirect live without a deploy.
+- Pattern redirects still work.
 
-## Phase 4: First UI Component Release
+## Phase A3: Storyblok Adapter Layer
 
-Status: `[ ]`
-
-Build in dependency order:
-
-- [ ] Typography
-- [ ] Container and layout primitives
-- [ ] Button
-- [ ] Icon button
-- [ ] Link
-- [ ] Field, label, help text, and error message
-- [ ] Input and textarea
-- [ ] Checkbox and radio
-- [ ] Tabs
-- [ ] Accordion
-- [ ] Dialog
-- [ ] Select
-
-Each component must include:
-
-- A typed, documented API
-- Keyboard and accessibility coverage
-- Story/workbench examples
-- Visual regression states
-- Loading, disabled, error, and empty states where applicable
-- Responsive verification
-- An explicit server or client component boundary
-
-Exit criteria:
-
-- The first release is usable without Storyblok.
-- Components share consistent composition, styling, focus, and state patterns.
-
-## Phase 5: Storyblok Adapter Layer
-
-Status: `[ ]`
+Status: `[ ]` Joins Track B — needs B3
 
 Keep Storyblok integration separate from `@sankara/ui`.
-
-Suggested structure:
-
-```text
-packages/storyblok-ui/
-├── adapters/
-├── mappings/
-├── schemas/
-└── test/
-```
 
 Responsibilities:
 
@@ -214,17 +167,16 @@ Responsibilities:
 Tasks:
 
 - [ ] Add committed schemas and generated types for button, header, footer,
-  navigation links, redirects, and site settings.
-- [ ] Add button, tabs, accordion, form, asset, link, and rich-text adapters.
+  navigation links, and site settings.
+- [ ] Add button, accordion, form, asset, link, and rich-text adapters.
 - [ ] Automate component registry generation from committed schemas.
-- [ ] Add schema/type drift checks to CI.
 
 Exit criteria:
 
 - No reusable UI component imports Storyblok packages or generated CMS types.
 - CMS adapters are typed, editor-safe, and covered by tests.
 
-## Phase 6: Reusable Page Sections
+## Phase A4: Reusable Page Sections
 
 Status: `[ ]`
 
@@ -247,7 +199,7 @@ Exit criteria:
   components rather than introducing local alternatives.
 - Storyblok child restrictions and semantic variants are encoded in schemas.
 
-## Phase 7: Integration Verification
+## Phase A5: Integration Verification
 
 Status: `[ ]`
 
@@ -259,14 +211,15 @@ Tasks:
 - [ ] Exercise draft entry/exit and visual-editor behavior.
 - [ ] Cover metadata, sitemap, robots, redirects, and 404 behavior.
 - [ ] Cover rich-text links and embedded bloks.
-- [ ] Cover webhook revalidation behavior.
+- [ ] Cover webhook revalidation behavior, including the route handler itself —
+  currently only its helpers are tested.
 
 Exit criteria:
 
 - Core authoring and visitor journeys are verified in a real browser.
 - Accessibility and visual regressions are visible in CI.
 
-## Phase 8: Project Bootstrap and Operations
+## Phase A6: Project Bootstrap and Operations
 
 Status: `[ ]`
 
@@ -276,36 +229,159 @@ Tasks:
   localized sitemap behavior.
 - [ ] Add a `yarn setup` initializer for site identity, locale, Storyblok region,
   analytics, consent integration, environment configuration, and starter bloks.
-- [ ] Add a private Sankara component registry if selected in Phase 2.
 - [ ] Add security headers and a CSP compatible with preview and integrations.
 - [ ] Add vendor-neutral logging and error-reporting hooks.
 - [ ] Add release notes, semantic versioning, and template update automation.
+- [ ] Declare `storyblok-js-client` explicitly — three files import it while
+  relying on it staying a transitive dependency of `@storyblok/react`.
 
 Exit criteria:
 
 - A new project can be configured without manual search-and-replace work.
 - Operational and security defaults are production-ready and documented.
 
-## Proposed PR Breakdown
+---
 
-| PR | Scope |
-| --- | --- |
-| A | CI and baseline reliability |
-| B | UI foundation spike and architecture decision |
-| C | `@sankara/ui` infrastructure and tokens |
-| D | Native UI components and form foundations |
-| E | Interactive components using the selected headless foundation |
-| F | Storyblok schemas, generated types, and adapter layer |
-| G | Starter section library |
-| H | Playwright, accessibility, and visual tests |
-| I | Setup CLI, localization, security, and operations |
+# Track B — `@sankara/ui`
+
+Runs in its own repository. Nothing here depends on Track A until Phase A3.
+
+## Phase B1: UI Foundation Decision
+
+Status: `[ ]`
+
+Run a focused Base UI versus Radix spike. Base UI is the current preference, but
+default styling is not a deciding factor.
+
+Build the same sample with both foundations. Use components that **already exist**
+in `numbers.ch/components/ui/` rather than an abstract Tabs/Dialog/Select set —
+their interaction requirements are known, which makes the comparison concrete:
+
+- `Expandable` (disclosure, animated height)
+- `CardSlider` (keyboard and pointer dragging, snap)
+- `Gallery` (overlay, focus trap, escape handling)
+- `Reveal` (scroll-triggered motion, reduced-motion behavior)
+- A server-rendered page containing client-side interaction
+
+Evaluate:
+
+- Accessibility and keyboard behavior
+- API consistency and composability
+- React Server Component boundaries
+- Styling and animation ergonomics
+- Bundle output
+- Test ergonomics
+- Portals and Content Security Policy compatibility
+- Upgrade and maintenance model
+
+Tasks:
+
+- [ ] Build and measure the Base UI sample.
+- [ ] Build and measure the Radix sample.
+- [ ] Record the decision in `docs/architecture/001-ui-foundation.md`.
+- [ ] Decide whether distribution uses a package, a private shadcn-compatible
+  registry, or both.
+
+Exit criteria:
+
+- The chosen foundation and rejected alternatives are documented with evidence.
+- The expected server/client boundary and dependency policy are explicit.
+
+## Phase B2: Foundation and Infrastructure
+
+Status: `[ ]`
+
+Establish the system before building a catalogue.
+
+Structure:
+
+```text
+src/
+├── components/
+├── hooks/
+├── styles/
+├── test/
+├── tokens/
+└── utilities/
+```
+
+Tasks:
+
+- [ ] Define semantic color, typography, spacing, radius, border, shadow,
+  motion, breakpoint, focus, and layering tokens.
+- [ ] Define theming and customer-brand override rules.
+- [ ] Document naming, composition, variants, refs, controlled state,
+  `className` escape hatches, and server/client boundaries.
+- [ ] Establish reduced-motion and accessibility acceptance policies.
+- [ ] Add Storybook or an equivalent isolated component workbench.
+- [ ] Add unit, accessibility, and visual-regression test infrastructure.
+- [ ] Establish package release and versioning workflows.
+
+Exit criteria:
+
+- Components can be developed and tested independently of Storyblok.
+- A consuming project can override brand tokens without forking component logic.
+- Accessibility and API rules are enforceable, not only documented.
+
+## Phase B3: First Component Release
+
+Status: `[ ]`
+
+The catalogue is derived from what a real site actually needed. Across
+`numbers.ch`'s 65 components, `components/ui/` grew to: `BgMark`, `CardSlider`,
+`CountUp`, `Expandable`, `Gallery`, `Glow`, `Icon`, `IconBox`, `Pill`, `Reveal`.
+Its only form is a nestable with raw inputs — no Field, Input, Select, Dialog or
+Checkbox primitive was ever extracted. Build what demand exists, not a generic
+design system.
+
+**Tier 1 — extract from numbers.ch, proven by use:**
+
+- [ ] Icon (plus icon-data generation)
+- [ ] Reveal (scroll-triggered motion)
+- [ ] Expandable (disclosure/accordion)
+- [ ] CardSlider
+- [ ] Gallery
+- [ ] CountUp
+- [ ] Pill, IconBox
+- [ ] Glow, BgMark (decorative)
+
+**Tier 2 — needed by every site, not yet extracted anywhere:**
+
+- [ ] Typography
+- [ ] Container and layout primitives
+- [ ] Button and Link (shared variant surface)
+- [ ] Field, label, help text, error message
+- [ ] Input and textarea
+
+**Deferred until a project actually needs them:** Dialog, Select, Tabs,
+Checkbox and radio. Revisit at the first real requirement; do not build on spec.
+
+Each component must include:
+
+- A typed, documented API
+- Keyboard and accessibility coverage
+- Story/workbench examples
+- Visual regression states
+- Loading, disabled, error, and empty states where applicable
+- Responsive verification
+- An explicit server or client component boundary
+
+Exit criteria:
+
+- The first release is usable without Storyblok.
+- Components share consistent composition, styling, focus, and state patterns.
+
+---
 
 ## Maintenance Rules
 
 - Update phase and task statuses in this document as work progresses.
+- Record architectural decisions under Decisions, with the rationale.
 - Add links to pull requests and architecture decisions when available.
 - Do not skip dependency phases without recording why.
 - Keep reusable UI APIs independent from Storyblok schemas.
 - Prefer semantic editor options over arbitrary visual controls.
 - Treat accessibility, responsive behavior, and reduced motion as acceptance
   criteria rather than later polish.
+- Before adding a component or phase, check whether a shipped project already
+  needed it. Evidence beats specification.


### PR DESCRIPTION
## Summary

Splits the roadmap into two parallel tracks and records the decision behind the split.

## The decision

`@sankara/ui` gets its own repository rather than becoming `packages/ui/` here. A template is cloned per project, so shipping the design-system source into every clone is backwards; the "override brand tokens without forking component logic" criterion is only tested honestly when the consumer is external; and a workspace conversion would restructure this repo's root and collide with every open branch.

That makes the tracks genuinely parallel — they only join at the adapter layer (A3).

## Corrections to the plan

- **The component catalogue was specification, not demand.** Across numbers.ch's 65 components, `components/ui/` grew to `BgMark`, `CardSlider`, `CountUp`, `Expandable`, `Gallery`, `Glow`, `Icon`, `IconBox`, `Pill`, `Reveal`. The old Phase 4 list (Dialog, Select, Checkbox, Tabs, Field/Input) overlaps that by roughly one component, and numbers.ch's only form is a nestable with raw inputs. B3 is now tiered: extract what shipped, build the primitives every site needs, defer the rest until something asks.
- **The Base UI vs Radix spike now uses components that exist** — `Expandable`, `CardSlider`, `Gallery`, `Reveal` — instead of an abstract sample.
- **CMS-editable redirects had no home**, despite being a live client requirement. Now Phase A2, marked `[!]` pending the matching-strategy decision, with the numbers.ch implementation's specific defects written down so they aren't re-inherited.
- **Phase 0's smoke test was silently marked done.** Reopened — everything downstream assumes that baseline works.
- Cleanup and backport findings from today's audits are now Phase A1.

## Note

Depends on nothing, but overlaps #13 in this one file. #13's version only edits status lines; this rewrite supersedes them.
