### PR TITLE
Hold eslint at 9 until eslint-config-next supports v10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
       # Bump both together.
       - dependency-name: '@types/node'
         update-types: [version-update:semver-major]
+      # eslint-plugin-react (via eslint-config-next) still peers on `^9.7` and calls
+      # context.getFilename(), removed in ESLint 10 — every lint run crashes. Drop this
+      # once eslint-config-next ships a plugin release supporting v10.
+      - dependency-name: 'eslint'
+        versions: ['10.x']
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Closes the loop on #18, which cannot be merged.

## Why

ESLint 10 removed the deprecated `context.getFilename()`. `eslint-plugin-react` — pulled in transitively by `eslint-config-next` — still calls it from `resolveBasedir`, so **every** lint run crashes before reporting anything:

```
TypeError: Error while loading rule 'react/display-name':
contextOrFilename.getFilename is not a function
    at resolveBasedir (node_modules/eslint-plugin-react/lib/util/version.js:31:100)
```

Reproduced locally on the #18 branch, not just in CI.

There is nothing to bump to: `eslint-plugin-react`'s peer range is `^3 || ... || ^9.7`, and the latest release (7.37.5) still declares it. `eslint-config-next` depends on `^7.37.0`. The fix has to come from upstream.

## What this does

Blocks Dependabot from re-proposing `eslint@10.x`, with a comment naming the exact condition for removing the ignore. Without it, #18 reopens weekly and CI stays red.

Scoped to `10.x` rather than all majors deliberately — an eslint 11 that fixes this should still surface.

## Verification

- `yarn check` green on this branch — formatting, ESLint 9, TypeScript, 39 tests, Storyblok type drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178C65jBpggDMNau5oUu3Cu