### PR TITLE
Design spec for the Storyblok space bootstrap

### DIFF
--- a/docs/enhancement-roadmap.md
+++ b/docs/enhancement-roadmap.md
@@ -161,10 +161,14 @@ Tasks:
 - [x] Define the `data/redirects` schema (source, destination, permanent) —
   documented in `README.md`.
 - [ ] Create the `redirect` blok and `redirects` content type in the Storyblok
-  space, then `yarn sync`. Needs a Management API token as `STORYBLOK_TOKEN` —
-  the name the CLI actually reads, not `.env.example`'s `STORYBLOK_OAUTH_TOKEN`,
-  which nothing reads. Until this lands `getRedirects()` reads a story that does
-  not exist and returns `[]`, so nothing redirects.
+  space, then `yarn sync`. Needs a CLI session from `storyblok login -r eu` using
+  the **email** method — a personal access token 403s on `/internal_tags`, which
+  both `components pull` and `push` call unconditionally. `STORYBLOK_TOKEN` in
+  `.env` is ignored unless `STORYBLOK_LOGIN` and `STORYBLOK_REGION` accompany it,
+  and `.env.example`'s `STORYBLOK_OAUTH_TOKEN` is read by nothing. See
+  `docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md`.
+  Until this lands `getRedirects()` reads a story that does not exist and returns
+  `[]`, so nothing redirects.
 - [x] Implement, preserving query strings and never trusting the Host header.
   Destinations come from the CMS as a path or absolute URL, so no origin is
   ever derived from a request header.

--- a/docs/enhancement-roadmap.md
+++ b/docs/enhancement-roadmap.md
@@ -161,9 +161,10 @@ Tasks:
 - [x] Define the `data/redirects` schema (source, destination, permanent) —
   documented in `README.md`.
 - [ ] Create the `redirect` blok and `redirects` content type in the Storyblok
-  space, then `yarn sync`. Needs `STORYBLOK_OAUTH_TOKEN`, which is not set
-  locally; until this lands `getRedirects()` reads a story that does not exist
-  and returns `[]`, so nothing redirects.
+  space, then `yarn sync`. Needs a Management API token as `STORYBLOK_TOKEN` —
+  the name the CLI actually reads, not `.env.example`'s `STORYBLOK_OAUTH_TOKEN`,
+  which nothing reads. Until this lands `getRedirects()` reads a story that does
+  not exist and returns `[]`, so nothing redirects.
 - [x] Implement, preserving query strings and never trusting the Host header.
   Destinations come from the CMS as a path or absolute URL, so no origin is
   ever derived from a request header.

--- a/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
@@ -137,10 +137,17 @@ committed baseline JSON is what earns a test, in vitest:
 
 - every blok named in a `component_whitelist` or restricted tag exists in the file
 - content types are `is_root`; nestables are `is_nestable`
-- every nestable in the baseline has a key in the `lib/storyblok.ts` registry
+- every nestable reachable from a **routable** content type's bloks fields has a
+  key in the `lib/storyblok.ts` registry
 
 The last assertion catches the failure `CLAUDE.md` warns about — a name mismatch
 causing a silent no-render — which is otherwise invisible until a page is loaded.
+
+"Routable" is load-bearing: `redirect` is a nestable, but it is reached only from
+`redirects`, a `data/` content type that `getRedirects()` parses as data and never
+renders. Requiring a registry key for it would force a renderer that does nothing.
+Data-only bloks are therefore exempt, and the test derives that from reachability
+rather than a hand-maintained exclusion list.
 
 ## Verified against the Template space (294223376817452)
 

--- a/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
@@ -81,9 +81,16 @@ requires:
 It renders through `RichTextRenderer` and `SbLink`, which is exactly what the
 Phase 0 smoke test needs to cover.
 
-`feature`, `grid` and `teaser` stay in the codebase. They are deleted from
-_newly bootstrapped_ spaces only; space `202685` still uses `grid` and `teaser`,
-so removing them from code would break the live space.
+`feature`, `grid` and `teaser` stay in the codebase — space `202685` still uses
+`grid` and `teaser`, so removing them from code would break the live space.
+
+Removing them from a _newly bootstrapped_ space is a **manual step**.
+`components push` creates and updates components but has no `--delete`, so the
+three Storyblok starters survive the push and must be deleted in the Storyblok
+UI afterwards. This is the accepted cost of choosing this approach over
+`schema push --delete` or a Management API script: deleting three bloks once per
+space does not justify either. `setup:space` prints the reminder as its closing
+output so the step is not silently skipped.
 
 ### Content
 
@@ -104,6 +111,10 @@ Together these cover every item on the unrun Phase 0 smoke test.
 ### Entry point
 
 `yarn setup:space --space <id> --yes`
+
+It runs the two push commands, then prints the manual follow-up: delete
+`feature`, `grid` and `teaser` in the Storyblok UI. The bootstrap is not
+complete until that is done.
 
 ## Guardrails
 
@@ -147,6 +158,10 @@ None change the design's shape; each has an obvious fallback.
   therefore: obtain `STORYBLOK_OAUTH_TOKEN`, run `components pull` and
   `stories pull` against a scratch space, observe the real formats, then author
   the baseline to match.
+- **Deleting the starter components is not automated.** `components push` has no
+  `--delete`; the step is manual and therefore skippable. If it proves annoying in
+  practice, the cheapest fix is a small Management API call in `setup:space`
+  rather than adopting `schema push`.
 - **The baseline will drift** as spaces evolve in the UI. This was an accepted
   trade-off of keeping the UI authoritative. The registry-coverage test limits the
   damage to code/schema mismatches; detecting genuine drift against a live space

--- a/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
@@ -1,0 +1,160 @@
+# Storyblok Space Bootstrap — Design
+
+Date: 2026-07-31
+Status: Approved, not yet implemented
+
+## Problem
+
+Standing up a Storyblok space for this template is manual. A fresh space arrives
+with Storyblok's starter structure (`page` plus `feature`/`grid`/`teaser`), which
+does not match the template's conventions, carries no `data/` folder, and gives no
+content to exercise the renderer against.
+
+Two consequences:
+
+- The Phase 0 smoke test (rich text, embedded bloks, preview editing, internal and
+  email links) has never been run, because no space is known to contain content
+  that covers those cases.
+- Phase A2's CMS redirects (PR #26) have no runtime verification at all — the
+  `redirects` content type does not exist in any space.
+
+## Decisions
+
+- **The Storyblok UI stays the source of truth for schema.** The committed
+  baseline exists to *bootstrap* a new space, not to govern existing ones.
+  `yarn sync` remains the workflow for real spaces. This preserves the existing
+  rule in `CLAUDE.md` rather than inverting it.
+- **The demo space is a reproducible dev/preview space, not a CI dependency.**
+  CI stays offline behind `STORYBLOK_SKIP_FETCH`. No integration tests, no read
+  tokens in CI, no network flakiness in the gate.
+- **One content type, `page`.** The homepage is the story at slug `home`, which
+  the catch-all already special-cases. No separate `home` type.
+- **`body` only, no `header` field.** A hero is the first section in `body`.
+- **Bootstrap via the existing CLI push commands**, not a code-driven schema DSL
+  and not a hand-rolled Management API script. Rationale under Approach below.
+
+## Approach
+
+`storyblok components push` and `storyblok stories push`, driven by committed
+JSON, wrapped in one script entry point.
+
+Rejected alternatives:
+
+- **`storyblok schema push` with a TypeScript entry file.** Purpose-built, handles
+  deletion via `--delete`, supports `--dry-run` and changeset rollback. Rejected
+  for now because the installed `storyblok@4.21.1` package exports only field
+  types — no schema DSL — so the entry-file format cannot be verified without
+  running `schema init` against a live space. It is also the code-driven
+  *governance* tool, which conflicts with keeping the UI authoritative. Worth
+  revisiting once the format has been observed.
+- **A `scripts/setup-space.mjs` over the Management API.** Full control including
+  deletion, but roughly 150 lines reimplementing what the CLI already does, to
+  automate deleting three bloks once per space.
+
+## What ships
+
+### Schema
+
+`.storyblok/components/baseline/components.baseline.json`, hand-authored and
+committed. Pushed with `components push --from baseline --suffix baseline`.
+
+| Component      | Kind                    | Fields                                                        |
+| -------------- | ----------------------- | ------------------------------------------------------------- |
+| `page`         | content type, `is_root` | `body` (bloks, restricted by tag `section`); `seo` (custom, `meta-fields`) inside an SEO tab |
+| `text_section` | nestable, tag `section` | `eyebrow` text, `headline` text, `lead` richtext, `link` multilink |
+| `redirects`    | content type, `is_root` | `entries` (bloks → `redirect`)                                |
+| `redirect`     | nestable                | `source` text, `destination` text, `permanent` boolean        |
+
+`text_section` uses the field vocabulary already documented in `CLAUDE.md`
+(`eyebrow`/`headline`/`lead`/`link`) and is whitelisted by tag per the same
+convention, so it serves as the worked example a contributor copies rather than
+throwaway demo filler.
+
+### Code
+
+A blok absent from the registry silently renders nothing, so the baseline also
+requires:
+
+- `components/nestables/TextSection.tsx`, generated via `yarn scaffold`
+- a `text_section` entry in the `lib/storyblok.ts` registry
+
+It renders through `RichTextRenderer` and `SbLink`, which is exactly what the
+Phase 0 smoke test needs to cover.
+
+`feature`, `grid` and `teaser` stay in the codebase. They are deleted from
+*newly bootstrapped* spaces only; space `202685` still uses `grid` and `teaser`,
+so removing them from code would break the live space.
+
+### Content
+
+`.storyblok/stories/baseline/`, pushed with `stories push --publish`.
+
+- **`home`** (`page`) — one `text_section` whose `lead` richtext contains a
+  paragraph with marks, an internal link, an email link, and an embedded blok.
+  The embedded blok is a nested `text_section`; recursive, which is the point —
+  it proves registry resolution works inside richtext.
+- **`about`** (`page`) — gives internal links a real target and makes
+  `generateStaticParams` return more than one path.
+- **`data/redirects`** (`redirects`) — one entry, `/alt` → `/about`, permanent.
+  `/alt` resolves to no story, so it 404s, reaches the redirect boundary, and
+  redirects. This makes the demo space a live end-to-end proof of Phase A2.
+
+Together these cover every item on the unrun Phase 0 smoke test.
+
+### Entry point
+
+`yarn setup:space --space <id> --yes`
+
+## Guardrails
+
+- `--space` is **mandatory**; the script must not fall back to
+  `STORYBLOK_SPACE_ID`. The local `.env` points at the live space `202685`, so a
+  bootstrap inheriting that default would push components into production.
+- The resolved target space is echoed, and `--yes` is required to proceed.
+  `components push` has no `--dry-run` (only `stories push` does), so explicit
+  confirmation is the guard rather than preview.
+- Missing authentication fails early naming `STORYBLOK_OAUTH_TOKEN`, matching how
+  `lib/env.ts` reports missing configuration.
+- Nothing writes to `.env`.
+
+## Testing
+
+The bootstrap itself is two CLI calls with little worth unit-testing. The
+committed baseline JSON is what earns a test, in vitest:
+
+- every blok named in a `component_whitelist` or restricted tag exists in the file
+- content types are `is_root`; nestables are `is_nestable`
+- every nestable in the baseline has a key in the `lib/storyblok.ts` registry
+
+The last assertion catches the failure `CLAUDE.md` warns about — a name mismatch
+causing a silent no-render — which is otherwise invisible until a page is loaded.
+
+## Open questions, to settle with a token
+
+None change the design's shape; each has an obvious fallback.
+
+1. Does `components push --from` accept a non-numeric directory name such as
+   `baseline`? The help text says "source space id". Fallback: keep the baseline
+   under a numeric directory.
+2. Is a stable tab key such as `tab-seo` valid, where the live space uses
+   `tab-<uuid>`? Fallback: generate a uuid-suffixed key.
+3. What layout does `stories push` expect under `.storyblok/stories/`?
+
+## Limitations, stated plainly
+
+- **Nothing here validates the file formats against Storyblok.** Only running the
+  bootstrap once against a scratch space does. The first implementation step is
+  therefore: obtain `STORYBLOK_OAUTH_TOKEN`, run `components pull` and
+  `stories pull` against a scratch space, observe the real formats, then author
+  the baseline to match.
+- **The baseline will drift** as spaces evolve in the UI. This was an accepted
+  trade-off of keeping the UI authoritative. The registry-coverage test limits the
+  damage to code/schema mismatches; detecting genuine drift against a live space
+  would need a token in CI, which the no-integration-tests decision rules out.
+
+## Dependencies
+
+- The `redirects` and `redirect` components, and the `data/redirects` story, are
+  only meaningful once **PR #26** (`feat/cms-redirects`, Phase A2) merges. The
+  baseline can be authored before then, but the end-to-end redirect proof requires
+  it.

--- a/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
@@ -126,8 +126,10 @@ complete until that is done.
 - The resolved target space is echoed, and `--yes` is required to proceed.
   `components push` has no `--dry-run` (only `stories push` does), so explicit
   confirmation is the guard rather than preview.
-- Missing authentication fails early naming `STORYBLOK_OAUTH_TOKEN`, matching how
-  `lib/env.ts` reports missing configuration.
+- Missing authentication fails early naming `STORYBLOK_TOKEN`, matching how
+  `lib/env.ts` reports missing configuration. Note the CLI reads `STORYBLOK_TOKEN`
+  (it loads `.env` via `dotenv/config`); `.env.example` currently documents
+  `STORYBLOK_OAUTH_TOKEN`, which nothing reads.
 - Nothing writes to `.env`.
 
 ## Testing
@@ -157,7 +159,8 @@ None change the design's shape; each has an obvious fallback.
 
 - **Nothing here validates the file formats against Storyblok.** Only running the
   bootstrap once against a scratch space does. The first implementation step is
-  therefore: obtain `STORYBLOK_OAUTH_TOKEN`, run `components pull` and
+  therefore: obtain a Management API token as `STORYBLOK_TOKEN`, run
+  `components pull` and
   `stories pull` against a scratch space, observe the real formats, then author
   the baseline to match.
 - **Deleting the starter components is not automated.** `components push` has no

--- a/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
@@ -94,7 +94,9 @@ output so the step is not silently skipped.
 
 ### Content
 
-`.storyblok/stories/baseline/`, pushed with `stories push --publish`.
+`.storyblok/stories/baseline/`, pushed with
+`stories push --from baseline --publish`. The `--from` is load-bearing: without
+it the CLI reads `.storyblok/stories/<target-space-id>/` and finds nothing.
 
 - **`home`** (`page`) — one `text_section` whose `lead` richtext contains a
   paragraph with marks, an internal link, an email link, and an embedded blok.

--- a/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
@@ -126,10 +126,8 @@ complete until that is done.
 - The resolved target space is echoed, and `--yes` is required to proceed.
   `components push` has no `--dry-run` (only `stories push` does), so explicit
   confirmation is the guard rather than preview.
-- Missing authentication fails early naming `STORYBLOK_TOKEN`, matching how
-  `lib/env.ts` reports missing configuration. Note the CLI reads `STORYBLOK_TOKEN`
-  (it loads `.env` via `dotenv/config`); `.env.example` currently documents
-  `STORYBLOK_OAUTH_TOKEN`, which nothing reads.
+- Missing authentication fails early with the fix in the message — see
+  Authentication below. A personal access token is not sufficient.
 - Nothing writes to `.env`.
 
 ## Testing
@@ -144,25 +142,52 @@ committed baseline JSON is what earns a test, in vitest:
 The last assertion catches the failure `CLAUDE.md` warns about — a name mismatch
 causing a silent no-render — which is otherwise invisible until a page is loaded.
 
-## Open questions, to settle with a token
+## Verified against the Template space (294223376817452)
 
-None change the design's shape; each has an obvious fallback.
+Settled empirically on 2026-07-31, authenticated as `emanuel@sankara.ch`:
 
-1. Does `components push --from` accept a non-numeric directory name such as
-   `baseline`? The help text says "source space id". Fallback: keep the baseline
-   under a numeric directory.
-2. Is a stable tab key such as `tab-seo` valid, where the live space uses
-   `tab-<uuid>`? Fallback: generate a uuid-suffixed key.
-3. What layout does `stories push` expect under `.storyblok/stories/`?
+1. **`--from` accepts a non-numeric directory name.** `const fromSpace =
+options.from || space` is used as a plain directory string with no numeric
+   validation, so `--from baseline` reads `<path>/components/baseline/`.
+   `components push` also hard-errors without `--space`, so part of the guardrail
+   is built into the CLI.
+2. **Component layout** is `<path>/components/<dir>/components.json`.
+3. **Story layout** is `<path>/stories/<dir>/<slug>_<uuid>.json`, each holding the
+   full story object (`content`, `full_slug`, `is_folder`, `is_startpage`, …).
+   Baseline stories therefore need stable hand-picked UUIDs.
+4. The target space contains exactly the Storyblok starter set — `feature`,
+   `grid`, `page`, `teaser` and one `home` story — so bootstrapping destroys
+   nothing of value.
+
+Still open, with a trivial fallback: is a stable tab key such as `tab-seo` valid,
+where the live space uses `tab-<uuid>`? Fallback: generate a uuid-suffixed key.
+
+## Authentication
+
+**The CLI needs a session created by `storyblok login` with the _email_ method.**
+This is not interchangeable with a personal access token:
+
+- Both `components pull` and `components push` call `fetchComponentInternalTags`
+  unconditionally, inside a `Promise.all`. A personal access token returns
+  `403 {"error":"This endpoint does not support this token type"}` on
+  `/v1/spaces/<id>/internal_tags`, which aborts the whole command. This is not
+  avoidable by keeping tags out of the baseline.
+- `STORYBLOK_TOKEN` in `.env` is ignored unless `STORYBLOK_LOGIN` **and**
+  `STORYBLOK_REGION` are also set — `getEnvCredentials()` requires all three or
+  falls through to the stored session in `~/.storyblok/credentials.json`.
+- `.env.example` documents `STORYBLOK_OAUTH_TOKEN`, which nothing reads.
+
+`setup:space` should therefore check for a working session rather than for an
+environment variable, and say "run `storyblok login -r eu` and choose email" when
+one is missing.
 
 ## Limitations, stated plainly
 
-- **Nothing here validates the file formats against Storyblok.** Only running the
-  bootstrap once against a scratch space does. The first implementation step is
-  therefore: obtain a Management API token as `STORYBLOK_TOKEN`, run
-  `components pull` and
-  `stories pull` against a scratch space, observe the real formats, then author
-  the baseline to match.
+- **The push direction is still unproven.** `components pull` and `stories pull`
+  have been run against the target space and the layouts are recorded above, but
+  no push has been attempted. Whether a hand-authored baseline is accepted as-is —
+  particularly the tab key and the `meta-fields` custom field — is only settled by
+  running it.
 - **Deleting the starter components is not automated.** `components push` has no
   `--delete`; the step is manual and therefore skippable. If it proves annoying in
   practice, the cheapest fix is a small Management API call in `setup:space`

--- a/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-07-31-storyblok-space-bootstrap-design.md
@@ -21,7 +21,7 @@ Two consequences:
 ## Decisions
 
 - **The Storyblok UI stays the source of truth for schema.** The committed
-  baseline exists to *bootstrap* a new space, not to govern existing ones.
+  baseline exists to _bootstrap_ a new space, not to govern existing ones.
   `yarn sync` remains the workflow for real spaces. This preserves the existing
   rule in `CLAUDE.md` rather than inverting it.
 - **The demo space is a reproducible dev/preview space, not a CI dependency.**
@@ -45,7 +45,7 @@ Rejected alternatives:
   for now because the installed `storyblok@4.21.1` package exports only field
   types — no schema DSL — so the entry-file format cannot be verified without
   running `schema init` against a live space. It is also the code-driven
-  *governance* tool, which conflicts with keeping the UI authoritative. Worth
+  _governance_ tool, which conflicts with keeping the UI authoritative. Worth
   revisiting once the format has been observed.
 - **A `scripts/setup-space.mjs` over the Management API.** Full control including
   deletion, but roughly 150 lines reimplementing what the CLI already does, to
@@ -58,12 +58,12 @@ Rejected alternatives:
 `.storyblok/components/baseline/components.baseline.json`, hand-authored and
 committed. Pushed with `components push --from baseline --suffix baseline`.
 
-| Component      | Kind                    | Fields                                                        |
-| -------------- | ----------------------- | ------------------------------------------------------------- |
+| Component      | Kind                    | Fields                                                                                       |
+| -------------- | ----------------------- | -------------------------------------------------------------------------------------------- |
 | `page`         | content type, `is_root` | `body` (bloks, restricted by tag `section`); `seo` (custom, `meta-fields`) inside an SEO tab |
-| `text_section` | nestable, tag `section` | `eyebrow` text, `headline` text, `lead` richtext, `link` multilink |
-| `redirects`    | content type, `is_root` | `entries` (bloks → `redirect`)                                |
-| `redirect`     | nestable                | `source` text, `destination` text, `permanent` boolean        |
+| `text_section` | nestable, tag `section` | `eyebrow` text, `headline` text, `lead` richtext, `link` multilink                           |
+| `redirects`    | content type, `is_root` | `entries` (bloks → `redirect`)                                                               |
+| `redirect`     | nestable                | `source` text, `destination` text, `permanent` boolean                                       |
 
 `text_section` uses the field vocabulary already documented in `CLAUDE.md`
 (`eyebrow`/`headline`/`lead`/`link`) and is whitelisted by tag per the same
@@ -82,7 +82,7 @@ It renders through `RichTextRenderer` and `SbLink`, which is exactly what the
 Phase 0 smoke test needs to cover.
 
 `feature`, `grid` and `teaser` stay in the codebase. They are deleted from
-*newly bootstrapped* spaces only; space `202685` still uses `grid` and `teaser`,
+_newly bootstrapped_ spaces only; space `202685` still uses `grid` and `teaser`,
 so removing them from code would break the live space.
 
 ### Content
@@ -154,7 +154,14 @@ None change the design's shape; each has an obvious fallback.
 
 ## Dependencies
 
-- The `redirects` and `redirect` components, and the `data/redirects` story, are
-  only meaningful once **PR #26** (`feat/cms-redirects`, Phase A2) merges. The
-  baseline can be authored before then, but the end-to-end redirect proof requires
-  it.
+- Phase A2's redirect resolution (**PR #26**, `feat/cms-redirects`) is merged, so
+  `lib/redirects.ts` and the 404-boundary lookup are on `main`. It is inert until
+  this bootstrap creates the `redirects` and `redirect` components and the
+  `data/redirects` story — which is what makes the demo space the first runtime
+  proof that A2 works.
+
+## Follow-up
+
+- Run `/simplify` across `lib/redirects.ts`, the catch-all integration, the
+  baseline JSON and `setup:space` once the bootstrap is fully implemented.
+  Deliberately deferred until the whole shape exists.


### PR DESCRIPTION
Spec only — no implementation. Records the design agreed in brainstorming for a scripted Storyblok space bootstrap, so a demo/test space (and any new client space) can be stood up reproducibly instead of clicked together by hand.

## Decisions recorded

- **The UI stays the schema source of truth.** The committed baseline bootstraps a *new* space; it does not govern existing ones. `yarn sync` remains the workflow, and the existing `CLAUDE.md` rule is preserved rather than inverted.
- **The demo space is a reproducible dev/preview space, not a CI dependency.** CI stays offline behind `STORYBLOK_SKIP_FETCH` — no read tokens in CI, no network in the gate.
- **One `page` content type**, `body` only (no `header` field), homepage is the story at slug `home`.
- **Bootstrap via existing CLI push commands**, not `storyblok schema push` and not hand-rolled Management API code.

## Why not `storyblok schema push`

It's the obvious candidate — it handles deletion (`--delete`), has `--dry-run` and changeset rollback. Rejected *for now* because the installed `storyblok@4.21.1` package exports only field types, no schema DSL, so the entry-file format can't be verified without running `schema init` against a live space. It's also the code-driven *governance* tool, which cuts against keeping the UI authoritative. Worth revisiting once the format has been observed.

## Scope this implies

Beyond the baseline JSON: a `text_section` blok needs a React component and a registry entry, or it silently renders nothing. Naming that now rather than discovering it mid-implementation.

## What it unblocks

The demo content covers every item on the **Phase 0 smoke test**, which has never been run. And `data/redirects` makes it the first runtime proof that Phase A2's redirects work — merged in #26 but inert until a space defines the schema.

## Honest limitations, in the spec

- Nothing here validates file formats against Storyblok; only running it against a scratch space does. First implementation step is therefore to get a token and observe the real formats.
- The baseline will drift as spaces evolve in the UI — an accepted trade-off of keeping the UI authoritative. Three open questions are listed with fallbacks; none change the design's shape.

## Note on provenance

Pushed via the GitHub Contents API rather than `git push` — the local git transport is failing with `RPC failed; HTTP 400` / `send-pack: unexpected disconnect`. Content is identical to the reviewed local commits; the two local commits are squashed into one here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178C65jBpggDMNau5oUu3Cu